### PR TITLE
Login pain points

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -41,7 +41,7 @@ class Login extends React.Component {
     entryButtons: {
       color: "white",
       backgroundColor: 'green',
-      boxShadow: '1px 2px 4px lightgreen'
+      boxShadow: '1px 2px 4px lightgreen',
     }
   });
 

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -37,6 +37,11 @@ class Login extends React.Component {
       ...theme.text.header,
       "text-align": "center",
       "margin-bottom": 0
+    },
+    entryButtons: {
+      color: "white",
+      backgroundColor: 'green',
+      boxShadow: '1px 2px 4px lightgreen'
     }
   });
 
@@ -104,19 +109,19 @@ class Login extends React.Component {
           {true && ( // displaySignUp
             <ButtonGroup fullWidth>
               <Button
-                color="default"
                 variant="contained"
                 onClick={() => this.handleClick("login")}
                 disabled={this.state.active === "login"}
+                className={this.state.active === "login" && css(this.styles.entryButtons)}
               >
                 Log In
               </Button>
               <Button
-                color="default"
                 variant="contained"
                 name="signup"
                 onClick={() => this.handleClick("signup")}
                 disabled={this.state.active === "signup"}
+                className={this.state.active === "signup" && css(this.styles.entryButtons)}
               >
                 Sign Up
               </Button>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -109,7 +109,7 @@ class Login extends React.Component {
           <img
             src="https://s3-us-west-1.amazonaws.com/spoke-public/spoke_logo.svg"
             className={css(this.styles.logoImg)}
-            width={150}
+            width={125}
           />
         </div>
         <div className={css(this.styles.header)}>

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -29,16 +29,17 @@ class Login extends React.Component {
     loginPage: {
       display: "flex",
       "justify-content": "center",
-      "align-items": "flex-start",
-      height: "100vh",
+      "flexDirection": "column",
+      "align-items": "center",
+      "minHeight": "100vh",
       "padding-top": "10vh"
     },
     header: {
       ...theme.text.header,
       "text-align": "center",
-      "margin-bottom": 0
+      "margin-bottom": 20
     },
-    entryButtons: {
+      entryButtons: {
       color: "white",
       backgroundColor: 'green',
       boxShadow: '1px 2px 4px lightgreen',
@@ -104,11 +105,22 @@ class Login extends React.Component {
 
     return (
       <div className={css(this.styles.loginPage)}>
+        <div className={css(this.styles.logoDiv)}>
+          <img
+            src="https://s3-us-west-1.amazonaws.com/spoke-public/spoke_logo.svg"
+            className={css(this.styles.logoImg)}
+            width={150}
+          />
+        </div>
+        <div className={css(this.styles.header)}>
+          Spoke is a new way to run campaigns using text messaging.
+        </div>
         <div>
           {/* Only display sign up option if there is a nextUrl */}
           {true && ( // displaySignUp
             <ButtonGroup fullWidth>
               <Button
+                color="default"
                 variant="contained"
                 onClick={() => this.handleClick("login")}
                 disabled={this.state.active === "login"}
@@ -117,6 +129,7 @@ class Login extends React.Component {
                 Log In
               </Button>
               <Button
+                color="default"
                 variant="contained"
                 name="signup"
                 onClick={() => this.handleClick("signup")}

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -7,6 +7,7 @@ import theme from "../styles/theme";
 import { withRouter } from "react-router";
 import Link from "@material-ui/core/Link";
 import { compose } from "recompose";
+import Login from "../components/Login";
 
 export const styles = StyleSheet.create({
   container: {
@@ -100,9 +101,7 @@ class Home extends React.Component {
           Spoke is a new way to run campaigns using text messaging.
         </div>
         <div>
-          <Link id="login" href="/login" onClick={this.handleOrgInviteClick}>
-            Login and get started 
-          </Link>
+          <Login />
         </div>
       </div>
     );
@@ -111,12 +110,6 @@ class Home extends React.Component {
   render() {
     return (
       <div className={css(styles.container)}>
-        <div className={css(styles.logoDiv)}>
-          <img
-            src="https://s3-us-west-1.amazonaws.com/spoke-public/spoke_logo.svg"
-            className={css(styles.logoImg)}
-          />
-        </div>
         <div className={css(styles.content)}>{this.renderContent()}</div>
       </div>
     );

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -101,7 +101,7 @@ class Home extends React.Component {
         </div>
         <div>
           <Link id="login" href="/login" onClick={this.handleOrgInviteClick}>
-            Login and get started
+            Login and get started 
           </Link>
         </div>
       </div>


### PR DESCRIPTION
# Fixes #4 Login 

## Description
This moves the Log in and Sign up form to the first page that a user sees. 
It also re-styles the Log in and Sign up form headers. 
It reduces a click for the user and makes the process of both logging in and signing up more intuitive and streamlined. 
The Login component is now called within Home.jsx

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress

### Before
![image](https://github.com/StateVoicesNational/Spoke_Hackathon_Fork/assets/117617970/1a70e19c-2c37-4071-87c3-e07b72ef20bc)

The words "Login and get started" confused some users who were signing up for the first time and did not have a login name and password. 
When a user clicked on **Login and get started** they were taken to this page: 

![image](https://github.com/StateVoicesNational/Spoke_Hackathon_Fork/assets/117617970/4d21d188-beb6-4e53-af5e-c5582c4cc628)

The header "Sign in" was more prominent when a user was on the Log in form and "Log in" was more bold when a user was on the Sign in form, leading to confusion for some users at the beginning. 

These fixes make the log in and sign up process more intuitive and easier for the users, both new and returning. 

### Now
<img width="816" alt="image" src="https://github.com/StateVoicesNational/Spoke_Hackathon_Fork/assets/117617970/188776c9-e517-4b9a-9cc9-8875c2c9b63a">

## Next steps

- Fix spacing for the logo and headline.

## Why we made this change

- It reduces the work a user must do to sign up or log in.
- The changes to the colors of the Login and Sign up header on the form allows a user to see which form they are on in a more intuitive way than before. 
